### PR TITLE
Fail on save compatibility baseline mismatch

### DIFF
--- a/CallOfTheWild/Testing/SaveCompatibility.cs
+++ b/CallOfTheWild/Testing/SaveCompatibility.cs
@@ -40,12 +40,17 @@ namespace EldritchArcana
 #if DEBUG
             var dir = Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location);
 
-            // If this doesn't match the previous baseline (or it didn't exist), write the current state.
-            if (MatchesBaseline(Path.Combine(dir, "baseline_assets.txt"))) return;
+            // If this doesn't match the previous baseline (or it didn't exist), write the current state
+            // and fail the test run so baseline updates are not ignored.
+            var matches = MatchesBaseline(Path.Combine(dir, "baseline_assets.txt"));
+            if (matches) return;
 
             WriteAssetInfo(Path.Combine(dir, "current_assets.txt"), GetCurrentAssetInfo());
 
             Log.Write(statefulComponentMessage.ToString());
+
+            throw new InvalidOperationException(
+                "Baseline assets mismatch detected. See current_assets.txt for details.");
 #endif
         }
 


### PR DESCRIPTION
## Summary
- ensure SaveCompatibility.CheckCompat fails tests when baseline assets mismatch

## Testing
- `dotnet build CallOfTheWild/CallOfTheWild.csproj` *(fails: reference assemblies for .NETFramework,Version=v4.8 were not found)*
- `xbuild CallOfTheWild/CallOfTheWild.csproj` *(fails: invalid language version 7.3 and unresolved UnityEngine references)*

------
https://chatgpt.com/codex/tasks/task_e_6893ddb44e788326952e97b3c7fd5ace