### PR TITLE
Resolve ambiguous LoadDictionary patch

### DIFF
--- a/CallOfTheWild/Main.cs
+++ b/CallOfTheWild/Main.cs
@@ -118,7 +118,10 @@ namespace CallOfTheWild
             }
             return true;
         }
-        [Harmony12.HarmonyPatch(typeof(LibraryScriptableObject), "LoadDictionary")]
+        // Specify the exact overload of LoadDictionary with no parameters to avoid
+        // ambiguity when Harmony searches for the original method.  A prior patch
+        // attempted to target the method name without specifying parameters which
+        // causes an AmbiguousMatchException when multiple overloads exist.
         [Harmony12.HarmonyPatch(typeof(LibraryScriptableObject), "LoadDictionary", new Type[0])]
         static class LibraryScriptableObject_LoadDictionary_Patch
         {


### PR DESCRIPTION
## Summary
- specify the parameterless `LoadDictionary` overload to prevent Harmony from throwing an `AmbiguousMatchException` during mod initialization

## Testing
- `xbuild CallOfTheWild.sln` *(fails: Invalid -langversion option `7.3`)*

------
https://chatgpt.com/codex/tasks/task_e_68941e95ba108326975c4860af29ee43