### PR TITLE
Fix ambiguous Harmony target for attack count patches

### DIFF
--- a/CallOfTheWild/NewMechanics/HoldingItemsMechanics.cs
+++ b/CallOfTheWild/NewMechanics/HoldingItemsMechanics.cs
@@ -951,8 +951,7 @@ namespace CallOfTheWild.HoldingItemsMechanics
     }
 
 
-    [Harmony12.HarmonyPatch(typeof(CharSAttack))]
-    [Harmony12.HarmonyPatch("SetupMainAttacks", Harmony12.MethodType.Normal)]
+    [Harmony12.HarmonyPatch(typeof(CharSAttack), "SetupMainAttacks", typeof(UnitDescriptor))]
     class CharSAttack__SetupMainAttacks__Patch
     {
         static IEnumerable<Harmony12.CodeInstruction> Transpiler(IEnumerable<Harmony12.CodeInstruction> instructions)
@@ -982,8 +981,7 @@ namespace CallOfTheWild.HoldingItemsMechanics
     }
 
 
-    [Harmony12.HarmonyPatch(typeof(RuleCalculateAttacksCount))]
-    [Harmony12.HarmonyPatch("OnTrigger", Harmony12.MethodType.Normal)]
+    [Harmony12.HarmonyPatch(typeof(RuleCalculateAttacksCount), "OnTrigger", typeof(RulebookEventContext))]
     class RuleCalculateAttacksCount__OnTrigger__Patch
     {
         /*static IEnumerable<Harmony12.CodeInstruction> Transpiler(IEnumerable<Harmony12.CodeInstruction> instructions)


### PR DESCRIPTION
## Summary
- Specify `UnitDescriptor` overload for `CharSAttack.SetupMainAttacks`
- Specify `RulebookEventContext` overload for `RuleCalculateAttacksCount.OnTrigger`

## Testing
- `xbuild CallOfTheWild/CallOfTheWild.csproj` *(fails: CSC: error CS1617: Invalid -langversion option `7.3'. It must be `ISO-1', `ISO-2', Default, Latest or value in range 1 to 7.2)*

------
https://chatgpt.com/codex/tasks/task_e_68942a3649d883268e46e12f1865d075